### PR TITLE
Fix tertiary attack

### DIFF
--- a/assets/characters/player/player_controller.gd
+++ b/assets/characters/player/player_controller.gd
@@ -94,7 +94,7 @@ func _unhandled_input(event: InputEvent) -> void:
 	if Input.is_action_just_pressed("tertiary"):
 		tertiary_down.emit()
 	
-	if Input.is_action_just_pressed("tertiary"):
+	if Input.is_action_just_released("tertiary"):
 		tertiary_up.emit()
 
 func _physics_process(delta) -> void:


### PR DESCRIPTION
Typo resulting in tertiary attack never firing when pressed.