### PR TITLE
Setup damage handling

### DIFF
--- a/assets/Abilities/damage_data.gd
+++ b/assets/Abilities/damage_data.gd
@@ -1,31 +1,19 @@
 extends Resource
 class_name DamageData
 
-@export var damage: float = 0
-@export var damage_type: Globals.DAMAGE_TYPES
-@export var damage_stats = DamageStats.new()
+## Flat damage
+@export var damage: float = 0 :
+	get:
+		return damage
+	set(value):
+		damage = value
+## Type of the damage, affected by resistances and multipliers
+@export var type: Globals.DAMAGE_TYPES:
+	get:
+		return type
 
 func copy() -> DamageData:
 	var copy = DamageData.new()
 	copy.damage = damage
-	copy.damage_type = damage_type
-	copy.damage_stats = damage_stats
+	copy.type = type
 	return copy
-
-func get_damage() -> float:
-	var d = damage
-	for dm in damage_stats.damage_modifiers:
-		if dm.get_type() == damage_type:
-			d += damage * dm.get_value()
-	return d
-
-func mod_stats(stats: DamageStats) -> void:
-	damage_stats.mod_stats(stats)
-
-func mod_data(data: DamageData) -> void:
-	damage += data.damage
-	damage_type = data.damage_type
-	damage_stats.mod_stats(data.damage_stats)
-
-func get_type() -> Globals.DAMAGE_TYPES:
-	return damage_type

--- a/assets/characters/player/player.tscn
+++ b/assets/characters/player/player.tscn
@@ -917,7 +917,6 @@ position_smoothing_enabled = true
 
 [node name="HealthComponent" parent="." node_paths=PackedStringArray("stats") instance=ExtResource("3_4p6c1")]
 stats = NodePath("../StatsComponent")
-max_health = null
 
 [node name="StatsComponent" parent="." instance=ExtResource("4_xg1r5")]
 

--- a/assets/stats/damage_modifier.gd
+++ b/assets/stats/damage_modifier.gd
@@ -1,13 +1,11 @@
 extends Resource
 class_name DamageModifier
 
-## Type of damage
-@export var type: Globals.DAMAGE_TYPES
-## Percentage modifier
-@export var value: float = 0
-
-func get_type() -> Globals.DAMAGE_TYPES:
-	return type
-
-func get_value() -> float:
-	return value
+## Damage Type
+@export var type: Globals.DAMAGE_TYPES :
+	get:
+		return type
+## Damage multiplier, a value of 0.5 will decrease by 50% and 2.0 will increase by 100%
+@export var value: float = 1 :
+	get:
+		return value

--- a/assets/stats/resistance_modifier.gd
+++ b/assets/stats/resistance_modifier.gd
@@ -1,11 +1,11 @@
 extends Resource
 class_name ResistModifier
 
-@export var type: Globals.DAMAGE_TYPES
-@export var value: int = 0
-
-func get_type() -> Globals.DAMAGE_TYPES:
-	return type
-
-func get_value() -> int:
-	return value
+## Damage Type
+@export var type: Globals.DAMAGE_TYPES :
+	get:
+		return type
+## Damage multiplier, a value of 0.5 will decrease by 50% and 2.0 will increase by 100%
+@export var value: float = 1 :
+	get:
+		return value

--- a/autoloads/floating_text_manager.gd
+++ b/autoloads/floating_text_manager.gd
@@ -1,0 +1,9 @@
+extends Node
+
+@onready var root = get_tree().root
+@onready var floating_damage = preload("res://scenes/ui/floating_damage.tscn")
+
+func create_damage_float(position: Vector2, damage: float) -> DamageFloat:
+	var damage_float = floating_damage.instantiate()
+	damage_float.update(position, damage)
+	return damage_float

--- a/components/health/health_component.gd
+++ b/components/health/health_component.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Node2D
 class_name HealthComponent
 
 signal health_changed(health_update)
@@ -34,9 +34,10 @@ var current_health: float :
 func _ready() -> void:
 	call_deferred("initialise_health")
 
-func damage(value: float) -> void:
-	current_health -= value
-	# create floating damage text
+func damage(damage: float) -> void:
+	current_health -= damage
+	var damage_float = FloatingTextManager.create_damage_float(global_position, damage)
+	add_child(damage_float)
 
 func heal(value: float) -> void:
 	damage(-value)

--- a/components/health/health_component.tscn
+++ b/components/health/health_component.tscn
@@ -2,5 +2,5 @@
 
 [ext_resource type="Script" path="res://components/health/health_component.gd" id="1_ym372"]
 
-[node name="HealthComponent" type="Node"]
+[node name="HealthComponent" type="Node2D"]
 script = ExtResource("1_ym372")

--- a/components/hitbox/hitbox_component.gd
+++ b/components/hitbox/hitbox_component.gd
@@ -1,14 +1,13 @@
 extends Area2D
 class_name HitboxComponent
 
-signal hit_by_projectile(projectile, final_damage)
-signal hit_by_hitbox(hitbox_component: HitboxComponent)
+signal hit_by_projectile(projectile, final_damage: DamageData)
+signal hit_by_hurtbox(hitbox_component: HitboxComponent, final_damage: DamageData)
 
 @export var health_component: HealthComponent
 @export var stats_component: StatsComponent
 @export var faction: Globals.FACTIONS = 0
 @export var detect_only: bool = false
-@export var damage: float = 1
 
 
 func can_accept_collisions() -> bool:
@@ -19,17 +18,18 @@ func handle_projectile_collision(projectile) -> void:
 	var damage = 0.0
 	if not detect_only:
 		damage = projectile.damage
-		damage = deal_damage_with_transforms(damage, projectile.damage_type)
+		damage = deal_damage_with_transforms(damage)
 	hit_by_projectile.emit(projectile, damage)
 
-func deal_damage_with_transforms(damage: float, damage_type: Globals.DAMAGE_TYPES) -> float:
-	var final_damage = stats_component.transform_damage(damage, damage_type) if stats_component != null \
-			 else damage
-	if health_component != null: health_component.damage(damage)
-	return final_damage
+func handle_hurbox_collision(hurtbox) -> void:
+	var damage = 0.0
+	if not detect_only:
+		damage = hurtbox.damage
+		damage = deal_damage_with_transforms(damage)
+	hit_by_hurtbox.emit(hurtbox, damage)
 
-func _on_area_entered(area: Area2D) -> void:
-	if area is HitboxComponent:
-		if not detect_only and area.faction != faction:
-			deal_damage_with_transforms(area.damage, Globals.DAMAGE_TYPES.PHYSICAL)
-		hit_by_hitbox.emit(area)
+func deal_damage_with_transforms(damage: DamageData) -> DamageData:
+	var final_damage = stats_component.apply_damage_resistances(damage) if stats_component != null \
+			 else damage
+	if health_component != null: health_component.damage(final_damage.damage)
+	return final_damage

--- a/components/hitbox/hitbox_component.tscn
+++ b/components/hitbox/hitbox_component.tscn
@@ -6,5 +6,3 @@
 collision_layer = 4
 collision_mask = 4
 script = ExtResource("1_m6w1q")
-
-[connection signal="area_entered" from="." to="." method="_on_area_entered"]

--- a/components/hurtbox/hurt_entity.gd
+++ b/components/hurtbox/hurt_entity.gd
@@ -1,0 +1,23 @@
+extends Resource
+class_name HurtEntity
+
+signal timeout(hurt_entity: HurtEntity)
+
+var area: Area2D
+var timer: Timer
+
+func set_data(entity: Area2D, rate: float) -> void:
+	area = entity
+	timer = Timer.new()
+	area.add_child(timer)
+	timer.wait_time = 1.0/rate
+	timer.connect("timeout", _timer_timeout)
+	timer.one_shot = true
+	timer.start()
+
+func get_area() -> Area2D:
+	return area
+
+func _timer_timeout() -> void:
+	area.remove_child(timer)
+	timeout.emit(self)

--- a/components/hurtbox/hurtbox_component.gd
+++ b/components/hurtbox/hurtbox_component.gd
@@ -1,0 +1,26 @@
+extends Area2D
+class_name HurtboxComponent
+
+## Faction that the hurtbox belongs
+@export var faction: Globals.FACTIONS = 0
+## Damage data of the hurtbox
+@export var damage: DamageData
+## Number of damage instances per second per entity
+@export var damage_rate: float = 1
+
+var hurt_entities: Array[HurtEntity] = []
+
+func _on_area_entered(area: Area2D) -> void:
+	if area is HitboxComponent:
+		if hurt_entities.filter(func(entity: HurtEntity): return entity.area == area).is_empty() \
+				and (area.faction != faction or area.faction == Globals.FACTIONS.NONE):
+			area.handle_hurbox_collision(self)
+			var hurt_entity = HurtEntity.new()
+			hurt_entity.set_data(area, damage_rate)
+			hurt_entity.connect("timeout", remove_entity)
+			hurt_entities.append(hurt_entity)
+
+func remove_entity(hurt_entity: HurtEntity) -> void:
+	hurt_entities.remove_at(hurt_entities.find(hurt_entity))
+	if hurt_entity.area in get_overlapping_areas():
+		_on_area_entered(hurt_entity.area)

--- a/components/hurtbox/hurtbox_component.tscn
+++ b/components/hurtbox/hurtbox_component.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3 uid="uid://cyds65pm1tk3p"]
+
+[ext_resource type="Script" path="res://components/hurtbox/hurtbox_component.gd" id="1_7jksb"]
+
+[node name="HurtboxComponent" type="Area2D"]
+collision_layer = 4
+collision_mask = 4
+script = ExtResource("1_7jksb")
+
+[connection signal="area_entered" from="." to="." method="_on_area_entered"]

--- a/components/stats/stats_component.gd
+++ b/components/stats/stats_component.gd
@@ -1,7 +1,7 @@
 extends Node
 class_name StatsComponent
 
-
+@export_category("Stat Multipliers")
 @export var health_mult: float = 1.0
 @export var stamina_mult: float = 1.0
 @export var mana_mult: float = 1.0
@@ -9,13 +9,25 @@ class_name StatsComponent
 @export var accelerate_mult: float = 1.0
 @export var defence_mult: float = 1.0
 
+@export_category("Damage Multipliers")
+## Array of damage resistances applied when recieving damage
+@export var damage_resistances: Array[ResistModifier]
+## Array of damage multipliers applied when dealing damage
+@export var damage_modifiers: Array[DamageModifier]
 
 # TODO
 # Handle stat modifiers (add, remove)
-# Handle damage reception modifiers
-# - apply_damage_resistances(damage) return damage
-# Handle damage dealt modifiers
-# - apply_damage_multipliers(damage) return damage
 
-func transform_damage(damage: float, damage_type: Globals.DAMAGE_TYPES) -> float:
-	return damage
+func apply_damage_resistances(damage: DamageData) -> DamageData:
+	var final_damage = damage.copy()
+	for resist in damage_resistances:
+		if resist.type == damage.type:
+			final_damage.damage *= resist.value
+	return final_damage
+
+func apply_damage_modifiers(damage: DamageData) -> DamageData:
+	var final_damage = damage.copy()
+	for mod in damage_modifiers:
+		if mod.type == damage.type:
+			final_damage.damage *= mod.value
+	return final_damage

--- a/components/velocity/velocity_component.gd
+++ b/components/velocity/velocity_component.gd
@@ -9,10 +9,13 @@ class_name VelocityComponent
 var calculated_max_speed : float :
 	get:
 		return max_speed * stats.speed_mult if stats else max_speed
+var calculated_acceleration: float :
+	get:
+		return acceleration * stats.accelerate_mult if stats else acceleration
 var velocity: Vector2 = Vector2.ZERO
 
 func accelerate_to_velocity(_velocity: Vector2) -> void:
-	velocity = velocity.lerp(_velocity, acceleration / calculated_max_speed)
+	velocity = velocity.lerp(_velocity, calculated_acceleration / calculated_max_speed)
 
 func accelerate_in_direction(direction: Vector2) -> void:
 	accelerate_to_velocity(direction * calculated_max_speed)

--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,7 @@ config/features=PackedStringArray("4.1", "Forward Plus")
 
 Globals="*res://autoloads/globals.gd"
 Utility="*res://autoloads/utility.gd"
+FloatingTextManager="*res://autoloads/floating_text_manager.gd"
 
 [input]
 

--- a/scenes/maps/test_map.tscn
+++ b/scenes/maps/test_map.tscn
@@ -1,10 +1,16 @@
-[gd_scene load_steps=5 format=3 uid="uid://dap4fb6jeula0"]
+[gd_scene load_steps=7 format=3 uid="uid://dap4fb6jeula0"]
 
 [ext_resource type="Texture2D" uid="uid://d22vih2q4mv7w" path="res://assets/interactable/ability_manager/campfire.png" id="1_peh4c"]
-[ext_resource type="PackedScene" uid="uid://ckwedti3q6wd3" path="res://components/hitbox/hitbox_component.tscn" id="2_8ixra"]
+[ext_resource type="PackedScene" uid="uid://cyds65pm1tk3p" path="res://components/hurtbox/hurtbox_component.tscn" id="2_argao"]
 [ext_resource type="PackedScene" uid="uid://d02dmv0nk6ijf" path="res://assets/characters/player/player.tscn" id="2_qc57j"]
+[ext_resource type="Script" path="res://assets/abilities/damage_data.gd" id="3_8hth5"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_aihpr"]
+[sub_resource type="Resource" id="Resource_38mf1"]
+script = ExtResource("3_8hth5")
+damage = 5.0
+type = 1
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_7ewh6"]
 
 [node name="TestMap" type="Node2D"]
 
@@ -20,10 +26,10 @@ texture = ExtResource("1_peh4c")
 position = Vector2(34, -21)
 texture = ExtResource("1_peh4c")
 
-[node name="HitboxComponent" parent="Sprite2D2" instance=ExtResource("2_8ixra")]
-detect_only = true
+[node name="HurtboxComponent" parent="Sprite2D2" instance=ExtResource("2_argao")]
+damage = SubResource("Resource_38mf1")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Sprite2D2/HitboxComponent"]
-shape = SubResource("RectangleShape2D_aihpr")
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Sprite2D2/HurtboxComponent"]
+shape = SubResource("RectangleShape2D_7ewh6")
 
 [node name="Player" parent="." instance=ExtResource("2_qc57j")]

--- a/scenes/ui/floating_damage.gd
+++ b/scenes/ui/floating_damage.gd
@@ -1,0 +1,22 @@
+extends Marker2D
+class_name DamageFloat
+
+@onready var label: Label = $Label
+@onready var timer: Timer = $Timer
+
+var amount: float = 0
+
+func _ready() -> void:
+	top_level = true
+	label.text = str(amount)
+	timer.start()
+
+func _process(delta: float) -> void:
+	global_position.y -= 50 * delta
+
+func update(pos: Vector2, damage: float) -> void:
+	global_position = pos
+	amount = roundf(damage)
+
+func _on_timer_timeout() -> void:
+	queue_free()

--- a/scenes/ui/floating_damage.tscn
+++ b/scenes/ui/floating_damage.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=2 format=3 uid="uid://bjxsyr3g8xdia"]
+
+[ext_resource type="Script" path="res://scenes/ui/floating_damage.gd" id="1_ejht5"]
+
+[node name="DamageFloat" type="Marker2D"]
+script = ExtResource("1_ejht5")
+
+[node name="Label" type="Label" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -50.0
+offset_top = -17.5
+offset_right = 50.0
+offset_bottom = 17.5
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 4
+theme_override_font_sizes/font_size = 10
+text = "500"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Timer" type="Timer" parent="."]
+one_shot = true
+
+[connection signal="timeout" from="Timer" to="." method="_on_timer_timeout"]


### PR DESCRIPTION
Separated the HitboxComponent into:
HitboxComponent
HurtboxComponent

Hitbox handles damage being recieved by an entity via HandleHurtboxCollision and HandleProjectileCollision methods. Hitboxs do not detect collisions themselves, instead being informed of a collision and handling it.
Hurtbox handles damage dealt by an entity by detecting collisions with a Hitbox.
In combination with the, yet to be made, ProjectileComponent this should handle all planned forms of dealing/recieving damage.